### PR TITLE
Support for video media, customizable upload options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 composer.lock
 test.php
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
         - EXECUTE_COVERAGE=true
     - php: 7.3
     - php: 7.4
+    - php: 8.0
 
 env:
   - COMPOSER_OPTS=""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2021-07-22
+
+* **Updated** PHPUnit version to `^9` to support PHP 8.0
+* **Updated** tests to work with PHPUnit `^9`
+* **Updated** Composer dependencies to latest versions
+* **Updated** ApiFacade to accommodate breaking changes in cloudinary_php `^2.0`
+* **Changed** ApiFacade no longer extends \Cloudinary\Api
+* **Added** ApiFacade defines its own deleteResourcesByPrefix
+* **Changed** references to delete_resources_by_prefix now use deleteResourcesByPrefix
+* **Added** explicit PHP types
+* **Changed** \Cloudinary\Api\Error to \Cloudinary\Api\Exception\ApiError
+* **Changed** ApiFacade::__construct() $options parameter to $cloudinaryOptions
+* **Updated** ApiFacade::__construct() to accept an additional $uploadOptions argument
+* **Updated** DataUri::__toString() to determine mime-type using only the first 1 MB of media content to avoid memory overflow problems with large files
+* **Removed** ApiFacade::deleteResources()
+* **Removed** ApiFacade::setUploadPreset()
+
+
+
 ## [1.3.0] - 2020-08-20
 
 * **Changed** Switched from [delete_resources](https://cloudinary.com/documentation/admin_api#delete_resources) to [destroy](https://cloudinary.com/documentation/image_upload_api_reference#destroy_method) API for file deletes. This allows to easier use `invalidate` option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.0] - 2021-07-22
 
+* **Updated** ApiFacade::upload() options to default to resource_type 'auto' _(adds video support)_
 * **Updated** PHPUnit version to `^9` to support PHP 8.0
 * **Updated** tests to work with PHPUnit `^9`
 * **Updated** Composer dependencies to latest versions

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Alex Panshin
+Copyright (c) 2021 Dalton Pierce
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +20,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ The library supports [Cloudinary Transformations](doc/transformations.md)!
 
 This fork includes some essential changes needed for my use-case. See CHANGELOG.md for a full list of changes, but here are the cliff notes:
 
-- Added explicit PHP types _(this will prevent compatibility with PHP `<7.4`)_
-- Updated dependencies _(PHP >=7.4, PHPUnit ^9, cloudinary_php ^2, php_codesniffer 3.*)_
+- Upload settings default to resource_type 'auto' in order to support video upload in addition to images
 - DataUri now reads the mime-type of media using only the first 1 MB, in order to prevent memory overflow for large files due to `finfo->buffer()`
 - ApiFacade constructor now accepts an uploadOptions argument containing options that are passed through to the Cloudinary SDK's upload function
+- Added explicit PHP types _(this will prevent compatibility with PHP `<7.4`)_
+- Updated dependencies _(PHP >=7.4, PHPUnit ^9, cloudinary_php ^2, php_codesniffer 3.*)_
 
 ### Using with Laravel-MediaLibrary
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,22 @@
-# Enl\Flysystem\Cloudinary
-[![Build Status](https://img.shields.io/travis/enl/flysystem-cloudinary/master.svg?style=flat-square)](https://travis-ci.org/enl/flysystem-cloudinary)
+# WeAreModus\Flysystem\Cloudinary
+
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
-[![Coverage Status](https://coveralls.io/repos/enl/flysystem-cloudinary/badge.svg?branch=master&service=github&style=flat-square)](https://coveralls.io/github/enl/flysystem-cloudinary?branch=master)
 
 This is a [Flysystem adapter](https://github.com/thephpleague/flysystem) for [Cloudinary API](http://cloudinary.com/documentation/php_integration).
 
 ## Installation
 
 ```bash
-composer require enl/flysystem-cloudinary '~1.0'
+composer require wearemodus/flysystem-cloudinary '~2.0'
 ```
 
 Or just add the following string to `require` part of your `composer.json`:
 
 ```json
 {
-    "require": {
-        "enl/flysystem-cloudinary": "~1.0"
-    }
+  "require": {
+    "wearemodus/flysystem-cloudinary": "~2.0"
+  }
 }
 ```
 
@@ -25,8 +24,8 @@ Or just add the following string to `require` part of your `composer.json`:
 
 ``` php
 <?php
-use Enl\Flysystem\Cloudinary\ApiFacade as CloudinaryClient;
-use Enl\Flysystem\Cloudinary\CloudinaryAdapter;
+use WeAreModus\Flysystem\Cloudinary\ApiFacade as CloudinaryClient;
+use WeAreModus\Flysystem\Cloudinary\CloudinaryAdapter;
 use League\Flysystem\Filesystem;
 
 include __DIR__ . '/vendor/autoload.php';
@@ -47,11 +46,89 @@ $filesystem = new Filesystem($adapter, ['disable_asserts' => true]);
 ## Cloudinary features
 
 Please, keep in mind three possible pain-in-asses of Cloudinary:
- 
-* It adds automatically file extension to its public_id. In terms of Flysystem, cloudinary's public_id is considered as filename. But if you set public_id as 'test.jpg' Cloudinary will save the file as 'test.jpg.jpg'. In order to work it around, you can use [PathConverterInterface](doc/path_converter.md).
+
+* It adds automatically file extension to its public_id. In terms of Flysystem, cloudinary's public_id is considered as filename. However, if you set public_id as 'test.jpg' Cloudinary will save the file as 'test.jpg.jpg'. In order to work
+  it around, you can use [PathConverterInterface](doc/path_converter.md).
 * It does not support folders creation through the API
-* If you want to save your files using folder you should set public_ids like 'test/test.jpg' and allow automated folders creation in your account settings in Cloudinary dashboard.
+* If you want to save your files using folder you should set public_ids like 'test/test.jpg' and allow automated folder creation in your account settings in Cloudinary dashboard.
 
 #### Good news!
 
 The library supports [Cloudinary Transformations](doc/transformations.md)!
+
+## WeAreModus Fork
+
+This fork includes some essential changes needed for my use-case. See CHANGELOG.md for a full list of changes, but here are the cliff notes:
+
+- Added explicit PHP types _(this will prevent compatibility with PHP `<7.4`)_
+- Updated dependencies _(PHP >=7.4, PHPUnit ^9, cloudinary_php ^2, php_codesniffer 3.*)_
+- DataUri now reads the mime-type of media using only the first 1 MB, in order to prevent memory overflow for large files due to `finfo->buffer()`
+- ApiFacade constructor now accepts an uploadOptions argument containing options that are passed through to the Cloudinary SDK's upload function
+
+### Using with Laravel-MediaLibrary
+
+In order to integrate this Cloudinary filesystem with Laravel-MediaLibrary, you will need to create a new filesystem driver as outline below:
+
+1. Define your Cloudinary `.env` variables
+    - `CLOUDINARY_CLOUD_NAME=`
+    - `CLOUDINARY_API_KEY=`
+    - `CLOUDINARY_API_SECRET=`
+1. Define a new filesystem driver in your `filesystems.php` config file _(within the 'disks' array)_
+   ```php
+   'disks' => [
+        ...
+   
+        'cloudinary' => [
+            'driver'     => 'cloudinary',
+            'cloud_name' => env('CLOUDINARY_CLOUD_NAME'),
+            'api_key'    => env('CLOUDINARY_API_KEY'),
+            'api_secret' => env('CLOUDINARY_API_SECRET'),
+        ],
+   ]
+   ```
+1. Create a new CloudinaryServiceProvider `php artisan make:provider CloudinarySeviceProvider`, and insert this code into the `boot()` method
+    ```php
+    use WeAreModus\Flysystem\Cloudinary\ApiFacade as CloudinaryClient;
+    use WeAreModus\Flysystem\Cloudinary\CloudinaryAdapter;
+    use WeAreModus\Flysystem\Cloudinary\Converter\TruncateExtensionConverter;
+    use Illuminate\Support\Facades\Storage;
+    use Illuminate\Support\ServiceProvider;
+    use League\Flysystem\Filesystem;
+   
+   ...
+   
+   public function boot() 
+   {
+        Storage::extend('cloudinary', function ($app, $config) {
+        $client = new CloudinaryClient(
+                [
+                    'cloud_name' => $config['cloud_name'],
+                    'api_key'    => $config['api_key'],
+                    'api_secret' => $config['api_secret'],
+                    'overwrite'  => $config['overwrite'] ?? true,
+                ], // Cloudinary API options
+                [
+                    'resource_type'          => 'auto',
+                    'eager'                  => [
+                        ['fetch_format' => 'mp4', 'format' => '', 'video_codec' => 'h264', 'quality' => '70'], // f_mp4,vc_h264,q_70
+                        ['fetch_format' => 'png', 'format' => '', 'quality' => '70'], // f_png,q_70
+                    ],
+                    'eager_async'            => 'true',
+                    'eager_notification_url' => 'https://mysite.test/webhook/eager',
+                    'notification_url'       => 'https://mysite.test/webhook/upload',
+                    ...
+                ], // Upload options
+                new TruncateExtensionConverter()
+           );
+            
+            return new Filesystem(new CloudinaryAdapter($client));
+        });
+   }
+   ```
+1. Finally, simply define `'cloudinary'` as your diskName when managing media
+    ```php
+    $this->addMediaCollection('videos')->useDisk('cloudinary'); // Use Cloudinary as disk for the entire collection
+    // OR
+    $model->addMedia($mediaPath)
+          ->toMediaCollection('videos', 'cloudinary'); // USe Cloudinary as disk for this media only
+   ```

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,35 @@
 {
-  "name": "enl/flysystem-cloudinary",
+  "name": "wearemodus/flysystem-cloudinary",
   "description": "Cloudinary adapter for Flysystem.",
   "license": "MIT",
   "authors": [
     {
       "name": "Alex Panshin",
       "email": "deadyaga@gmail.com"
+    },
+    {
+      "name": "Dalton Pierce",
+      "email": "dnnp2011@gmail.com"
     }
   ],
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=7.4",
     "ext-fileinfo": "*",
-    "league/flysystem": "^1.0.26",
-    "cloudinary/cloudinary_php": "^1.8.0"
+    "league/flysystem": "^1.1",
+    "cloudinary/cloudinary_php": "^2"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "^2.3.1",
-    "phpunit/phpunit": "^6"
+    "squizlabs/php_codesniffer": "3.*",
+    "phpunit/phpunit": "^9"
   },
   "autoload": {
     "psr-4": {
-      "Enl\\Flysystem\\Cloudinary\\": "src/"
+      "WeAreModus\\Flysystem\\Cloudinary\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Enl\\Flysystem\\Cloudinary\\Test\\": "tests/"
+      "WeAreModus\\Flysystem\\Cloudinary\\Test\\": "tests/"
     },
     "files": [
       "tests/polyfill.php"

--- a/doc/path_converter.md
+++ b/doc/path_converter.md
@@ -6,7 +6,7 @@ As you might know, Cloudinary does not include file's extension in its `public_i
 This interface is as simple as this:
 
 ```php
-namespace Enl\Flysystem\Cloudinary\Converter;
+namespace WeAreModus\Flysystem\Cloudinary\Converter;
 
 interface PathConverterInterface
 {
@@ -34,17 +34,27 @@ By default, Api facade uses `AsIsPathConverter` which performs no conversions. I
 
 
 ```php
-use Enl\Flysystem\Cloudinary\ApiFacade;
-use Enl\Flysystem\Cloudinary\Converter\TruncateExtensionConverter;
+use WeAreModus\Flysystem\Cloudinary\ApiFacade;
+use WeAreModus\Flysystem\Cloudinary\Converter\TruncateExtensionConverter;
 
-$options = [
-   'cloud_name' => 'your-cloudname-here',
-   'api_key' => 'api-key',
-   'api_secret' => 'You-know-what-to-do',
-   'overwrite' => true, // set this to true if you want to overwrite existing files using $filesystem->write();
+$cloudinaryOptions = [
+   'cloud_name' => 'your-cloudname',
+   'api_key' => 'your-api-key',
+   'api_secret' => 'your-api-secret',
+   'overwrite' => true, // Set this to true if you want to overwrite existing files using $filesystem->write();
 ];
 
-$client = new ApiFacade($options, new TruncateExtensionConverter());
+$uploadOptions = [
+    'eager' => [
+        ['fetch_format' => 'mp4', 'format' => '', 'video_codec' => 'h264', 'quality' => '70'],
+        ['fetch_format' => 'png', 'format' => '', 'quality' => '70'],
+    ],
+    'eager_async' => 'true',
+    'eager_notification_url' => 'https://mysite.test/webhook/eager',
+    'notification_url' => 'https://mysite.test/webhook/upload',
+];
+
+$client = new ApiFacade($cloudinaryOptions, $uploadOptions, new TruncateExtensionConverter());
 ```
 
 TruncateExtensionConverter

--- a/doc/transformations.md
+++ b/doc/transformations.md
@@ -27,10 +27,10 @@ There are two plugins: one of them returns `url` of transformed image, another o
 
 ``` php
 <?php
-use Enl\Flysystem\Cloudinary\ApiFacade as CloudinaryClient;
-use Enl\Flysystem\Cloudinary\CloudinaryAdapter;
-use Enl\Flysystem\Cloudinary\Plugin\ReadTransformation;
-use Enl\Flysystem\Cloudinary\Plugin\GetUrl;
+use WeAreModus\Flysystem\Cloudinary\ApiFacade as CloudinaryClient;
+use WeAreModus\Flysystem\Cloudinary\CloudinaryAdapter;
+use WeAreModus\Flysystem\Cloudinary\Plugin\ReadTransformation;
+use WeAreModus\Flysystem\Cloudinary\Plugin\GetUrl;
 use League\Flysystem\Filesystem;
 
 include __DIR__ . '/vendor/autoload.php';

--- a/src/ApiFacade.php
+++ b/src/ApiFacade.php
@@ -64,7 +64,6 @@ class ApiFacade
      */
     public function resource($path, $options = [])
     {
-        // $resource = parent::resource($this->converter->pathToId($path));
         $resource = (new AdminApi())->asset($this->converter->pathToId($path));
 
         return $this->addPathToResource($resource);

--- a/src/Converter/AsIsPathConverter.php
+++ b/src/Converter/AsIsPathConverter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Converter;
+namespace WeAreModus\Flysystem\Cloudinary\Converter;
 
-use Cloudinary\Api\Response;
+use Cloudinary\Api\ApiResponse;
 
 /**
  * Class AsIsPathConverter
@@ -15,9 +15,10 @@ class AsIsPathConverter implements PathConverterInterface
      * Converts path to public Id
      *
      * @param string $path
+     *
      * @return string
      */
-    public function pathToId($path)
+    public function pathToId(string $path): string
     {
         return $path;
     }
@@ -25,11 +26,12 @@ class AsIsPathConverter implements PathConverterInterface
     /**
      * Converts id to path
      *
-     * @param Response $resource
+     * @param ApiResponse $id
+     *
      * @return string
      */
-    public function idToPath($resource)
+    public function idToPath(array $id): string
     {
-        return $resource['public_id'];
+        return $id['public_id'];
     }
 }

--- a/src/Converter/PathConverterInterface.php
+++ b/src/Converter/PathConverterInterface.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Converter;
-
-use Cloudinary\Api\Response;
+namespace WeAreModus\Flysystem\Cloudinary\Converter;
 
 /**
  * This interface is used to convert given path to cloudinary public id and vice versa
@@ -19,15 +17,17 @@ interface PathConverterInterface
      * Converts path to public Id
      *
      * @param string $path
+     *
      * @return string
      */
-    public function pathToId($path);
+    public function pathToId(string $path): string;
 
     /**
      * Converts id to path
      *
-     * @param Response $id
+     * @param array $id
+     *
      * @return string
      */
-    public function idToPath($id);
+    public function idToPath(array $id): string;
 }

--- a/src/Converter/TruncateExtensionConverter.php
+++ b/src/Converter/TruncateExtensionConverter.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Converter;
-
-use Cloudinary\Api\Response;
+namespace WeAreModus\Flysystem\Cloudinary\Converter;
 
 class TruncateExtensionConverter implements PathConverterInterface
 {
@@ -10,25 +8,27 @@ class TruncateExtensionConverter implements PathConverterInterface
      * Converts path to public Id
      *
      * @param string $path
+     *
      * @return string
      */
-    public function pathToId($path)
+    public function pathToId(string $path): string
     {
         $extension = pathinfo($path, PATHINFO_EXTENSION);
 
         return $extension
-            ? substr($path, 0, - (strlen($extension) + 1))
+            ? substr($path, 0, -(strlen($extension) + 1))
             : $path;
     }
 
     /**
      * Converts id to path
      *
-     * @param Response $resource
+     * @param array $id
+     *
      * @return string
      */
-    public function idToPath($resource)
+    public function idToPath(array $id): string
     {
-        return $resource['public_id'] . '.' . $resource['format'];
+        return $id['public_id'] . '.' . $id['format'];
     }
 }

--- a/src/DataUri.php
+++ b/src/DataUri.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary;
+namespace WeAreModus\Flysystem\Cloudinary;
 
 /**
  * Class DataUri
@@ -12,16 +12,13 @@ namespace Enl\Flysystem\Cloudinary;
  */
 class DataUri
 {
-    /** @var string */
-    private $content;
-
-    /** @var \finfo */
-    private $finfo;
+    private string $content;
+    private \finfo $finfo;
 
     /**
      * @param string $content
      */
-    public function __construct($content)
+    public function __construct(string $content)
     {
         $this->content = $content;
     }
@@ -29,7 +26,7 @@ class DataUri
     /**
      * @return \finfo
      */
-    private function getFileInfo()
+    private function getFileInfo(): \finfo
     {
         if (!$this->finfo) {
             $this->finfo = new \finfo(FILEINFO_MIME_TYPE);
@@ -45,7 +42,7 @@ class DataUri
     {
         return sprintf(
             'data:%s;base64,%s',
-            $this->getFileInfo()->buffer($this->content),
+            $this->getFileInfo()->buffer(substr($this->content, 0, 1024 * 1024)),
             base64_encode($this->content)
         );
     }

--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -1,22 +1,16 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Plugin;
+namespace WeAreModus\Flysystem\Cloudinary\Plugin;
 
-use Enl\Flysystem\Cloudinary\ApiFacade;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\PluginInterface;
+use WeAreModus\Flysystem\Cloudinary\ApiFacade;
 
 abstract class AbstractPlugin implements PluginInterface
 {
-    /**
-     * @var FilesystemInterface
-     */
-    protected $filesystem;
+    protected FilesystemInterface $filesystem;
 
-    /**
-     * @var ApiFacade
-     */
-    protected $apiFacade;
+    protected ApiFacade $apiFacade;
 
     public function __construct(ApiFacade $facade)
     {

--- a/src/Plugin/GetUrl.php
+++ b/src/Plugin/GetUrl.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Plugin;
+namespace WeAreModus\Flysystem\Cloudinary\Plugin;
 
 class GetUrl extends AbstractPlugin
 {
@@ -9,12 +9,12 @@ class GetUrl extends AbstractPlugin
      *
      * @return string
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return 'getUrl';
     }
 
-    public function handle($path, $options = [])
+    public function handle(string $path, array $options = []): string
     {
         return $this->apiFacade->url($path, $options);
     }

--- a/src/Plugin/GetVersionedUrl.php
+++ b/src/Plugin/GetVersionedUrl.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Plugin;
+namespace WeAreModus\Flysystem\Cloudinary\Plugin;
 
 class GetVersionedUrl extends AbstractPlugin
 {
@@ -11,7 +11,7 @@ class GetVersionedUrl extends AbstractPlugin
      *
      * @return string
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return 'getVersionedUrl';
     }
@@ -23,11 +23,11 @@ class GetVersionedUrl extends AbstractPlugin
      * api calls limit of your cloudinary plan.
      *
      * @param string $path
-     * @param array $options
+     * @param array  $options
      *
      * @return string
      */
-    public function handle($path, $options = [])
+    public function handle(string $path, array $options = []): string
     {
         $options[self::VERSION_OPTION] = $options[self::VERSION_OPTION] ?? $this->getLatestVersion($path);
 
@@ -39,7 +39,7 @@ class GetVersionedUrl extends AbstractPlugin
      *
      * @return int|mixed
      */
-    private function getLatestVersion($path)
+    private function getLatestVersion(string $path): mixed
     {
         $resource = $this->apiFacade->resource($path);
 

--- a/src/Plugin/ReadTransformation.php
+++ b/src/Plugin/ReadTransformation.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Plugin;
+namespace WeAreModus\Flysystem\Cloudinary\Plugin;
 
 class ReadTransformation extends AbstractPlugin
 {
@@ -9,7 +9,7 @@ class ReadTransformation extends AbstractPlugin
      *
      * @return string
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return 'readTransformation';
     }

--- a/tests/AdapterAction/ActionTestCase.php
+++ b/tests/AdapterAction/ActionTestCase.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\AdapterAction;
+namespace WeAreModus\Flysystem\Cloudinary\Test\AdapterAction;
 
-use Enl\Flysystem\Cloudinary\ApiFacade;
-use Enl\Flysystem\Cloudinary\CloudinaryAdapter;
 use PHPUnit\Framework\TestCase;
+use WeAreModus\Flysystem\Cloudinary\ApiFacade;
+use WeAreModus\Flysystem\Cloudinary\CloudinaryAdapter;
 
 abstract class ActionTestCase extends TestCase
 {
     /**
      * @return [CloudinaryAdapter, ApiFacade]
      */
-    final protected function buildAdapter()
+    final protected function buildAdapter(): array
     {
         $api = $this->prophesize(ApiFacade::class);
 

--- a/tests/AdapterAction/CreateDirTest.php
+++ b/tests/AdapterAction/CreateDirTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\AdapterAction;
+namespace WeAreModus\Flysystem\Cloudinary\Test\AdapterAction;
 
 use League\Flysystem\Config;
 
 class CreateDirTest extends ActionTestCase
 {
-    public function createDirProvider()
+    public function createDirProvider(): array
     {
         return [
             ['path', ['path' => 'path/', 'type' => 'dir']],
@@ -16,6 +16,7 @@ class CreateDirTest extends ActionTestCase
 
     /**
      * @dataProvider createDirProvider
+     *
      * @param $path
      * @param $expected
      */

--- a/tests/AdapterAction/DeleteTest.php
+++ b/tests/AdapterAction/DeleteTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\AdapterAction;
+namespace WeAreModus\Flysystem\Cloudinary\Test\AdapterAction;
 
-use Cloudinary\Api\Error;
+use Cloudinary\Api\Exception\ApiError;
 
 class DeleteTest extends ActionTestCase
 {
@@ -16,7 +16,7 @@ class DeleteTest extends ActionTestCase
     public function testReturnsFalseOnException()
     {
         list($cloudinary, $api) = $this->buildAdapter();
-        $api->deleteFile('file')->willThrow(Error::class);
+        $api->deleteFile('file')->willThrow(ApiError::class);
         $this->assertFalse($cloudinary->delete('file'));
     }
 
@@ -30,7 +30,7 @@ class DeleteTest extends ActionTestCase
     public function testDeleteDirSuccess()
     {
         list($cloudinary, $api) = $this->buildAdapter();
-        $api->delete_resources_by_prefix('path/')->willReturn(['deleted' => []]);
+        $api->deleteResourcesByPrefix('path/')->willReturn(['deleted' => []]);
 
         $this->assertTrue($cloudinary->deleteDir('path'));
         $this->assertTrue($cloudinary->deleteDir('path/'), 'deleteDir must be idempotent');
@@ -39,7 +39,7 @@ class DeleteTest extends ActionTestCase
     public function testDeleteDirFailure()
     {
         list($cloudinary, $api) = $this->buildAdapter();
-        $api->delete_resources_by_prefix('path/')->willThrow(Error::class);
+        $api->deleteResourcesByPrefix('path/')->willThrow(ApiError::class);
         $this->assertFalse($cloudinary->deleteDir('path/'));
     }
 }

--- a/tests/AdapterAction/GetMetadataTest.php
+++ b/tests/AdapterAction/GetMetadataTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\AdapterAction;
+namespace WeAreModus\Flysystem\Cloudinary\Test\AdapterAction;
 
-use Cloudinary\Api\Error;
+use Cloudinary\Api\Exception\ApiError;
 
 class GetMetadataTest extends ActionTestCase
 {
-    public function metadataProvider()
+    public function metadataProvider(): array
     {
         return [
             ['getMetadata'],
@@ -19,6 +19,7 @@ class GetMetadataTest extends ActionTestCase
 
     /**
      * @dataProvider  metadataProvider
+     *
      * @param $method
      */
     public function testMetadataCallsSuccess($method)
@@ -33,11 +34,11 @@ class GetMetadataTest extends ActionTestCase
         $api->resource('file')->willReturn(compact('public_id', 'path', 'bytes', 'created_at', 'version'));
 
         $expected = [
-            'type' => 'file',
-            'path' => $public_id,
-            'size' => $bytes,
+            'type'      => 'file',
+            'path'      => $public_id,
+            'size'      => $bytes,
             'timestamp' => strtotime($created_at),
-            'version' => $version,
+            'version'   => $version,
         ];
         $actual = $cloudinary->$method($public_id);
 
@@ -46,12 +47,13 @@ class GetMetadataTest extends ActionTestCase
 
     /**
      * @param $method
+     *
      * @dataProvider metadataProvider
      */
     public function testMetadataCallsFailure($method)
     {
         list($cloudinary, $api) = $this->buildAdapter();
-        $api->resource('path')->willThrow(Error::class);
+        $api->resource('path')->willThrow(ApiError::class);
 
         $this->assertFalse($cloudinary->{$method}('path'));
     }

--- a/tests/AdapterAction/ListContentsTest.php
+++ b/tests/AdapterAction/ListContentsTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\AdapterAction;
+namespace WeAreModus\Flysystem\Cloudinary\Test\AdapterAction;
 
-use Cloudinary\Error;
+use Cloudinary\Api\Exception\ApiError;
 use Prophecy\Argument;
 
 class ListContentsTest extends ActionTestCase
@@ -10,7 +10,7 @@ class ListContentsTest extends ActionTestCase
     public function testReturnsEmptyArrayOnError()
     {
         list($cloudinary, $api) = $this->buildAdapter();
-        $api->resources(Argument::any())->shouldBeCalled()->willThrow(Error::class);
+        $api->resources(Argument::any())->shouldBeCalled()->willThrow(ApiError::class);
         $this->assertEquals([], $cloudinary->listContents());
     }
 
@@ -32,14 +32,14 @@ class ListContentsTest extends ActionTestCase
         ];
 
         $api->resources($request)->shouldBeCalled()->willReturn([
-            'resources' => array_slice($expected, 0, 2),
-            'next_cursor' => 'cursor'
+            'resources'   => array_slice($expected, 0, 2),
+            'next_cursor' => 'cursor',
         ]);
 
         $api->resources(array_merge($request, ['next_cursor' => 'cursor']))
             ->shouldBeCalled()
             ->willReturn([
-                'resources' => array_slice($expected, 2)
+                'resources' => array_slice($expected, 2),
             ]);
 
         $actual = $cloudinary->listContents();
@@ -79,15 +79,15 @@ class ListContentsTest extends ActionTestCase
         $version = time();
 
         $api->resources(Argument::any())->willReturn([
-            'resources' => [compact('public_id', 'path', 'bytes', 'created_at', 'version')]
+            'resources' => [compact('public_id', 'path', 'bytes', 'created_at', 'version')],
         ]);
 
         $expected = [
-            'type' => 'file',
-            'path' => $public_id,
-            'size' => $bytes,
+            'type'      => 'file',
+            'path'      => $public_id,
+            'size'      => $bytes,
             'timestamp' => strtotime($created_at),
-            'version' => $version,
+            'version'   => $version,
         ];
 
         $actual = $cloudinary->listContents()[0];

--- a/tests/AdapterAction/ReadTest.php
+++ b/tests/AdapterAction/ReadTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\AdapterAction;
+namespace WeAreModus\Flysystem\Cloudinary\Test\AdapterAction;
 
-use Cloudinary\Error;
+use Cloudinary\Api\Exception\ApiError;
 
 class ReadTest extends ActionTestCase
 {
@@ -10,7 +10,7 @@ class ReadTest extends ActionTestCase
     {
         list($cloudinary, $api) = $this->buildAdapter();
 
-        $api->content('file')->shouldBeCalled()->willThrow(Error::class);
+        $api->content('file')->shouldBeCalled()->willThrow(ApiError::class);
 
         $this->assertFalse($cloudinary->read('file'));
         $this->assertFalse($cloudinary->readStream('file'));
@@ -31,8 +31,8 @@ class ReadTest extends ActionTestCase
         $api->content('file')->willReturn(fopen('php://memory', 'r+'));
         $response = $cloudinary->readStream('file');
 
-        $this->assertInternalType('array', $response);
+        $this->assertIsArray($response);
         $this->assertEquals('file', $response['path']);
-        $this->assertInternalType('resource', $response['stream']);
+        $this->assertIsResource($response['stream']);
     }
 }

--- a/tests/AdapterAction/RenameTest.php
+++ b/tests/AdapterAction/RenameTest.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\AdapterAction;
+namespace WeAreModus\Flysystem\Cloudinary\Test\AdapterAction;
 
-use Cloudinary\Error;
+use Cloudinary\Api\Exception\ApiError;
 
 /**
  * Class RenameTest
- * @package Enl\Flysystem\Cloudinary\Test\AdapterAction
- * @todo what to do with folder rename?
+ * @package WeAreModus\Flysystem\Cloudinary\Test\AdapterAction
+ * @todo    what to do with folder rename?
  */
 class RenameTest extends ActionTestCase
 {
     public function testReturnsFalseOnFailure()
     {
         list($cloudinary, $api) = $this->buildAdapter();
-        $api->rename('old', 'new')->willThrow(Error::class);
+        $api->rename('old', 'new')->willThrow(ApiError::class);
         $this->assertFalse($cloudinary->rename('old', 'new'));
     }
 

--- a/tests/AdapterAction/UpdateTest.php
+++ b/tests/AdapterAction/UpdateTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\AdapterAction;
+namespace WeAreModus\Flysystem\Cloudinary\Test\AdapterAction;
 
-use Cloudinary\Error;
+use Cloudinary\Api\Exception\ApiError;
 use League\Flysystem\Config;
 use Prophecy\Argument;
 
@@ -11,7 +11,7 @@ class UpdateTest extends ActionTestCase
     public function testReturnsFalseOnFailure()
     {
         list($cloudinary, $api) = $this->buildAdapter();
-        $api->upload(Argument::any(), Argument::any(), Argument::any())->willThrow(Error::class);
+        $api->upload(Argument::any(), Argument::any(), Argument::any())->willThrow(ApiError::class);
         $this->assertFalse($cloudinary->update('path', 'contents', new Config()));
     }
 
@@ -20,8 +20,8 @@ class UpdateTest extends ActionTestCase
         list($cloudinary, $api) = $this->buildAdapter();
         $api->upload('test-path', 'contents', true)->willReturn([
             'public_id' => 'test-path',
-            'path' => 'test-path',
-            'bytes' => 123123
+            'path'      => 'test-path',
+            'bytes'     => 123123,
         ]);
 
         $response = $cloudinary->update('test-path', 'contents', new Config());

--- a/tests/AdapterAction/VisibilityTest.php
+++ b/tests/AdapterAction/VisibilityTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\AdapterAction;
+namespace WeAreModus\Flysystem\Cloudinary\Test\AdapterAction;
 
 /**
  * Visibility is not supported for Cloudinary,
  * so that this test just checks if the methods always return NotSupportedException
  *
- * @package Enl\Flysystem\Cloudinary\Test\AdapterAction
+ * @package WeAreModus\Flysystem\Cloudinary\Test\AdapterAction
  */
 class VisibilityTest extends ActionTestCase
 {

--- a/tests/AdapterAction/WriteTest.php
+++ b/tests/AdapterAction/WriteTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\AdapterAction;
+namespace WeAreModus\Flysystem\Cloudinary\Test\AdapterAction;
 
-use Cloudinary\Error;
+use Cloudinary\Api\Exception\ApiError;
 use League\Flysystem\Config;
 
 class WriteTest extends ActionTestCase
@@ -12,7 +12,7 @@ class WriteTest extends ActionTestCase
         list($cloudinary, $api) = $this->buildAdapter();
         $api->upload('path', 'contents', false)
             ->shouldBeCalled()
-            ->willThrow(Error::class);
+            ->willThrow(ApiError::class);
 
         $this->assertFalse($cloudinary->write('path', 'contents', new Config()));
     }
@@ -22,7 +22,7 @@ class WriteTest extends ActionTestCase
         list($cloudinary, $api) = $this->buildAdapter();
         $api->upload('path', '', false)
             ->shouldBeCalled()
-            ->willThrow(Error::class);
+            ->willThrow(ApiError::class);
 
         $this->assertFalse($cloudinary->writeStream('path', fopen('php://memory', 'r+'), new Config()));
     }
@@ -39,8 +39,8 @@ class WriteTest extends ActionTestCase
         list($cloudinary, $api) = $this->buildAdapter();
         $api->upload($path, is_resource($content) ? stream_get_contents($content) : $content, false)->willReturn([
             'public_id' => $path,
-            'path' => $path,
-            'bytes' => 123123
+            'path'      => $path,
+            'bytes'     => 123123,
         ]);
         $response = $cloudinary->$method($path, $content, new Config());
 
@@ -48,11 +48,11 @@ class WriteTest extends ActionTestCase
         $this->assertEquals('test-path', $response['path']);
     }
 
-    public function writeParametersProvider()
+    public function writeParametersProvider(): array
     {
         return [
-            'write' => ['write', 'test-path', 'content'],
-            'writeStream' => ['writeStream', 'test-path', fopen('php://memory', 'r+')]
+            'write'       => ['write', 'test-path', 'content'],
+            'writeStream' => ['writeStream', 'test-path', fopen('php://memory', 'r+')],
         ];
     }
 }

--- a/tests/ApiFacadeTest.php
+++ b/tests/ApiFacadeTest.php
@@ -1,26 +1,26 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test;
+namespace WeAreModus\Flysystem\Cloudinary\Test;
 
-use Enl\Flysystem\Cloudinary\ApiFacade;
+use Cloudinary\Configuration\Configuration;
 use PHPUnit\Framework\TestCase;
+use WeAreModus\Flysystem\Cloudinary\ApiFacade;
 
 /**
  * Class ApiFacadeTest
  * Almost all the tests here a very simple just because
  * ApiFacade delegates everything to different parts of Cloudinary API library
- * @package Enl\Flysystem\Cloudinary\Test
+ * @package WeAreModus\Flysystem\Cloudinary\Test
  */
 class ApiFacadeTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static $cloudinary_url_result;
+    public static $fopen_result;
+
+    public static function setUpBeforeClass(): void
     {
         require_once __DIR__ . '/fixtures/functions.php';
     }
-
-    public static $cloudinary_url_result;
-
-    public static $fopen_result;
 
     public function testContent()
     {
@@ -44,18 +44,8 @@ class ApiFacadeTest extends TestCase
     public function testConfigure()
     {
         $api = new ApiFacade();
-        $api->configure(['upload_preset' => 'preset']);
+        $api->configure(['api' => ['callback_url' => 'http://test.test']]);
 
-        $actual = \Cloudinary::config_get('upload_preset');
-
-        $this->assertEquals('preset', $actual);
-    }
-
-    public function testSetUploadPreset()
-    {
-        $api = new ApiFacade();
-        $api->setUploadPreset('preset');
-
-        $this->assertEquals('preset', \Cloudinary::config_get('upload_preset'));
+        $this->assertEquals('http://test.test', Configuration::instance()->api->callbackUrl);
     }
 }

--- a/tests/Converter/AsIsPathConverterTest.php
+++ b/tests/Converter/AsIsPathConverterTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\Converter;
+namespace WeAreModus\Flysystem\Cloudinary\Test\Converter;
 
-use Enl\Flysystem\Cloudinary\Converter\AsIsPathConverter;
-use Enl\Flysystem\Cloudinary\Converter\PathConverterInterface;
 use PHPUnit\Framework\TestCase;
+use WeAreModus\Flysystem\Cloudinary\Converter\AsIsPathConverter;
+use WeAreModus\Flysystem\Cloudinary\Converter\PathConverterInterface;
 
 class AsIsPathConverterTest extends TestCase
 {
     /** @var PathConverterInterface */
     private $converter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->converter = new AsIsPathConverter();
     }
@@ -24,7 +24,7 @@ class AsIsPathConverterTest extends TestCase
     public function testIdToPath()
     {
         $this->assertEquals('file.png', $this->converter->idToPath([
-            'public_id' => 'file.png'
+            'public_id' => 'file.png',
         ]));
     }
 
@@ -32,7 +32,7 @@ class AsIsPathConverterTest extends TestCase
     {
         $resource = [
             'public_id' => 'file',
-            'format' => 'png'
+            'format'    => 'png',
         ];
 
         $path = $this->converter->idToPath($resource);

--- a/tests/Converter/TruncateExtensionConverterTest.php
+++ b/tests/Converter/TruncateExtensionConverterTest.php
@@ -1,17 +1,16 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\Converter;
+namespace WeAreModus\Flysystem\Cloudinary\Test\Converter;
 
-use Enl\Flysystem\Cloudinary\Converter\PathConverterInterface;
-use Enl\Flysystem\Cloudinary\Converter\TruncateExtensionConverter;
 use PHPUnit\Framework\TestCase;
+use WeAreModus\Flysystem\Cloudinary\Converter\PathConverterInterface;
+use WeAreModus\Flysystem\Cloudinary\Converter\TruncateExtensionConverter;
 
 class TruncateExtensionConverterTest extends TestCase
 {
-    /** @var PathConverterInterface */
-    private $converter;
+    private PathConverterInterface $converter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->converter = new TruncateExtensionConverter();
     }
@@ -25,7 +24,7 @@ class TruncateExtensionConverterTest extends TestCase
     {
         $this->assertEquals('file.png', $this->converter->idToPath([
             'public_id' => 'file',
-            'format' => 'png'
+            'format'    => 'png',
         ]));
     }
 
@@ -33,7 +32,7 @@ class TruncateExtensionConverterTest extends TestCase
     {
         $resource = [
             'public_id' => 'file',
-            'format' => 'png'
+            'format'    => 'png',
         ];
 
         $path = $this->converter->idToPath($resource);

--- a/tests/Plugin/GetUrlTest.php
+++ b/tests/Plugin/GetUrlTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\Plugin;
+namespace WeAreModus\Flysystem\Cloudinary\Test\Plugin;
 
-use Enl\Flysystem\Cloudinary\ApiFacade;
-use Enl\Flysystem\Cloudinary\CloudinaryAdapter;
-use Enl\Flysystem\Cloudinary\Plugin\GetUrl;
 use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
+use WeAreModus\Flysystem\Cloudinary\ApiFacade;
+use WeAreModus\Flysystem\Cloudinary\CloudinaryAdapter;
+use WeAreModus\Flysystem\Cloudinary\Plugin\GetUrl;
 
 class GetUrlTest extends TestCase
 {

--- a/tests/Plugin/GetVersionedUrlTest.php
+++ b/tests/Plugin/GetVersionedUrlTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\Plugin;
+namespace WeAreModus\Flysystem\Cloudinary\Test\Plugin;
 
-use Enl\Flysystem\Cloudinary\ApiFacade;
-use Enl\Flysystem\Cloudinary\CloudinaryAdapter;
-use Enl\Flysystem\Cloudinary\Plugin\GetVersionedUrl;
 use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
+use WeAreModus\Flysystem\Cloudinary\ApiFacade;
+use WeAreModus\Flysystem\Cloudinary\CloudinaryAdapter;
+use WeAreModus\Flysystem\Cloudinary\Plugin\GetVersionedUrl;
 
 class GetVersionedUrlTest extends TestCase
 {

--- a/tests/Plugin/ReadTransformationTest.php
+++ b/tests/Plugin/ReadTransformationTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary\Test\Plugin;
+namespace WeAreModus\Flysystem\Cloudinary\Test\Plugin;
 
-use Enl\Flysystem\Cloudinary\ApiFacade;
-use Enl\Flysystem\Cloudinary\CloudinaryAdapter;
-use Enl\Flysystem\Cloudinary\Plugin\ReadTransformation;
 use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
+use WeAreModus\Flysystem\Cloudinary\ApiFacade;
+use WeAreModus\Flysystem\Cloudinary\CloudinaryAdapter;
+use WeAreModus\Flysystem\Cloudinary\Plugin\ReadTransformation;
 
 class ReadTransformationTest extends TestCase
 {

--- a/tests/fixtures/functions.php
+++ b/tests/fixtures/functions.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Enl\Flysystem\Cloudinary;
+namespace WeAreModus\Flysystem\Cloudinary;
 
-use Enl\Flysystem\Cloudinary\Test\ApiFacadeTest;
+use WeAreModus\Flysystem\Cloudinary\Test\ApiFacadeTest;
 
-function cloudinary_url($path, array $parameters = [])
+function cloudinary_url(string $path, array $parameters = [])
 {
     return ApiFacadeTest::$cloudinary_url_result;
 }
 
-function fopen($path, $attributes)
+function fopen(string $path, string $attributes)
 {
     return ApiFacadeTest::$fopen_result;
 }

--- a/tests/polyfill.php
+++ b/tests/polyfill.php
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  *
  * @copyright Copyright (c) Ben Ramsey (http://benramsey.com)
- * @license http://opensource.org/licenses/MIT MIT
+ * @license   http://opensource.org/licenses/MIT MIT
  */
 if (!function_exists('array_column')) {
     /**
@@ -17,14 +17,15 @@ if (!function_exists('array_column')) {
      * Optionally, you may provide an $indexKey to index the values in the returned
      * array by the values from the $indexKey column in the input array.
      *
-     * @param array $input A multi-dimensional array (record set) from which to pull
-     *                     a column of values.
+     * @param array $input     A multi-dimensional array (record set) from which to pull
+     *                         a column of values.
      * @param mixed $columnKey The column of values to return. This value may be the
      *                         integer key of the column you wish to retrieve, or it
      *                         may be the string key name for an associative array.
-     * @param mixed $indexKey (Optional.) The column to use as the index/keys for
-     *                        the returned array. This value may be the integer key
-     *                        of the column, or it may be the string key name.
+     * @param mixed $indexKey  (Optional.) The column to use as the index/keys for
+     *                         the returned array. This value may be the integer key
+     *                         of the column, or it may be the string key name.
+     *
      * @return array
      */
     function array_column($input = null, $columnKey = null, $indexKey = null)
@@ -64,13 +65,13 @@ if (!function_exists('array_column')) {
             return false;
         }
         $paramsInput = $params[0];
-        $paramsColumnKey = ($params[1] !== null) ? (string) $params[1] : null;
+        $paramsColumnKey = ($params[1] !== null) ? (string)$params[1] : null;
         $paramsIndexKey = null;
         if (isset($params[2])) {
             if (is_float($params[2]) || is_int($params[2])) {
-                $paramsIndexKey = (int) $params[2];
+                $paramsIndexKey = (int)$params[2];
             } else {
-                $paramsIndexKey = (string) $params[2];
+                $paramsIndexKey = (string)$params[2];
             }
         }
         $resultArray = [];
@@ -79,7 +80,7 @@ if (!function_exists('array_column')) {
             $keySet = $valueSet = false;
             if ($paramsIndexKey !== null && array_key_exists($paramsIndexKey, $row)) {
                 $keySet = true;
-                $key = (string) $row[$paramsIndexKey];
+                $key = (string)$row[$paramsIndexKey];
             }
             if ($paramsColumnKey === null) {
                 $valueSet = true;


### PR DESCRIPTION
* **Updated** ApiFacade::upload() options to default to resource_type 'auto' _(adds video support)_
* **Updated** PHPUnit version to `^9` to support PHP 8.0
* **Updated** tests to work with PHPUnit `^9`
* **Updated** Composer dependencies to latest versions
* **Updated** ApiFacade to accommodate breaking changes in cloudinary_php `^2.0`
* **Changed** ApiFacade no longer extends \Cloudinary\Api
* **Added** ApiFacade defines its own deleteResourcesByPrefix
* **Changed** references to delete_resources_by_prefix now use deleteResourcesByPrefix
* **Added** explicit PHP types
* **Changed** \Cloudinary\Api\Error to \Cloudinary\Api\Exception\ApiError
* **Changed** ApiFacade::__construct() $options parameter to $cloudinaryOptions
* **Updated** ApiFacade::__construct() to accept an additional $uploadOptions argument
* **Updated** DataUri::__toString() to determine mime-type using only the first 1 MB of media content to avoid memory overflow problems with large files
* **Removed** ApiFacade::deleteResources()
* **Removed** ApiFacade::setUploadPreset()